### PR TITLE
fix  error: format not a string literal and no format arguments

### DIFF
--- a/src/php_ahocorasick.c
+++ b/src/php_ahocorasick.c
@@ -330,7 +330,7 @@ static inline int php_ahocorasick_process_pattern(zend_long pidx, ahocorasick_pa
 #if PHP7
         zend_throw_exception(aho_exception_ce, exception_buffer, 0 TSRMLS_CC);
 #else
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, exception_buffer);
+        php_error_docref(NULL TSRMLS_CC, E_ERROR, "%s", exception_buffer);
 #endif
     }
     return returnCode;


### PR DESCRIPTION
Bulding with  -Werror=format-security option

```
BUILDSTDERR: /builddir/build/BUILD/php56-php-pecl-ahocorasick-0.0.3/NTS/src/php_ahocorasick.c: In function 'php_ahocorasick_process_pattern':
BUILDSTDERR: /builddir/build/BUILD/php56-php-pecl-ahocorasick-0.0.3/NTS/src/php_ahocorasick.c:333:51: error: format not a string literal and no format arguments [-Werror=format-security]
BUILDSTDERR:          php_error_docref(NULL TSRMLS_CC, E_ERROR, exception_buffer);
BUILDSTDERR:                                                    ^~~~~~~~~~~~~~~~

```