### PR TITLE
add 7.3, 7.4 and 8.0 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ php:
   - 7.1
   # aliased to a recent 7.2.x version
   - 7.2
+  # aliased to a recent 7.3.x version
+  - 7.3
+  # aliased to a recent 7.4.x version
+  - "7.4snapshot"
+  # aliased the most recent 8.x branch
+  - nightly
   # aliased to a recent hhvm version
   - hhvm
 
@@ -53,4 +59,5 @@ script:
 # optionally set up exclutions and allowed failures in the matrix
 matrix:
   allow_failures:
+    - php: nightly
     - php: hhvm


### PR DESCRIPTION
At least 7.3/7.4 have 1 failed test which need investigation
```
TEST 1/5 [tests/test1.phpt]
========DIFF========
009+     *RECURSION*
009-     array(1) {
010-       [0]=>
011-       int(1)
012-     }
========DONE========
FAIL Test 1 [tests/test1.phpt] 

```