### PR TITLE
fix reported version in phpinfo / reflection

### DIFF
--- a/src/php_ahocorasick.c
+++ b/src/php_ahocorasick.c
@@ -63,13 +63,11 @@ static zend_function_entry ahocorasick_functions[] = {
     PHP_FE(ahocorasick_isValid, NULL)
     PHP_FE(ahocorasick_finalize, NULL)
     PHP_FE(ahocorasick_add_patterns, NULL)
-    {NULL, NULL, NULL}
+    PHP_FE_END
 };
 
 zend_module_entry ahocorasick_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
     STANDARD_MODULE_HEADER,
-#endif
     PHP_AHOCORASICK_EXTNAME,
     ahocorasick_functions,
     PHP_MINIT(ahocorasick),
@@ -77,9 +75,7 @@ zend_module_entry ahocorasick_module_entry = {
     PHP_RINIT(ahocorasick),
     NULL,
     NULL,
-#if ZEND_MODULE_API_NO >= 20010901
     PHP_AHOCORASICK_VERSION,
-#endif
     STANDARD_MODULE_PROPERTIES
 };
 

--- a/src/php_ahocorasick.h
+++ b/src/php_ahocorasick.h
@@ -122,7 +122,7 @@ ZEND_END_MODULE_GLOBALS(ahocorasick)
 #define AHOCORASICK_G(v) (ahocorasick_globals.v)
 #endif
 
-#define PHP_AHOCORASICK_VERSION "2.0"
+#define PHP_AHOCORASICK_VERSION "0.0.4"
 #define PHP_AHOCORASICK_EXTNAME "ahocorasick"
 
 /**


### PR DESCRIPTION
Of course this have to be fixed in release process of each version

For now:
```
$ php --ri ahocorasick 

ahocorasick

Version => 2.0
```

Which is confusing for users