### PR TITLE
add arginfo to all functions for reflection

### DIFF
--- a/src/php_ahocorasick.c
+++ b/src/php_ahocorasick.c
@@ -56,13 +56,33 @@ static char exception_buffer[8192];
 
 ZEND_DECLARE_MODULE_GLOBALS(ahocorasick)
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_match, 0, 0, 2)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_INFO(0, findAll)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_id, 0, 0, 1)
+	ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_init, 0, 0, 1)
+	ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_add_patterns, 0, 0, 2)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_INFO(0, patterns)
+ZEND_END_ARG_INFO()
+
+
 static zend_function_entry ahocorasick_functions[] = {
-    PHP_FE(ahocorasick_match, NULL)
-    PHP_FE(ahocorasick_init, NULL)
-    PHP_FE(ahocorasick_deinit, NULL)
-    PHP_FE(ahocorasick_isValid, NULL)
-    PHP_FE(ahocorasick_finalize, NULL)
-    PHP_FE(ahocorasick_add_patterns, NULL)
+    PHP_FE(ahocorasick_match,          arginfo_ahocorasick_match)
+    PHP_FE(ahocorasick_init,           arginfo_ahocorasick_init)
+    PHP_FE(ahocorasick_deinit,         arginfo_ahocorasick_id)
+    PHP_FE(ahocorasick_isValid,        arginfo_ahocorasick_id)
+    PHP_FE(ahocorasick_finalize,       arginfo_ahocorasick_id)
+    PHP_FE(ahocorasick_add_patterns,   arginfo_ahocorasick_add_patterns)
     PHP_FE_END
 };
 


### PR DESCRIPTION
Before: 
```
$ php  --re ahocorasick
Extension [ <persistent> extension #73 ahocorasick version 2.0 ] {

  - Functions {
    Function [ <internal:ahocorasick> function ahocorasick_match ] {
    }
    Function [ <internal:ahocorasick> function ahocorasick_init ] {
    }
    Function [ <internal:ahocorasick> function ahocorasick_deinit ] {
    }
    Function [ <internal:ahocorasick> function ahocorasick_isValid ] {
    }
    Function [ <internal:ahocorasick> function ahocorasick_finalize ] {
    }
    Function [ <internal:ahocorasick> function ahocorasick_add_patterns ] {
    }
  }
...
```

After:
```
$ php  --re ahocorasick
Extension [ <persistent> extension #15 ahocorasick version 0.0.4 ] {

  - Functions {
    Function [ <internal:ahocorasick> function ahocorasick_match ] {

      - Parameters [3] {
        Parameter #0 [ <required> $needle ]
        Parameter #1 [ <required> $id ]
        Parameter #2 [ <optional> $findAll ]
      }
    }
    Function [ <internal:ahocorasick> function ahocorasick_init ] {

      - Parameters [1] {
        Parameter #0 [ <required> $data ]
      }
    }
    Function [ <internal:ahocorasick> function ahocorasick_deinit ] {

      - Parameters [1] {
        Parameter #0 [ <required> $id ]
      }
    }
    Function [ <internal:ahocorasick> function ahocorasick_isValid ] {

      - Parameters [1] {
        Parameter #0 [ <required> $id ]
      }
    }
    Function [ <internal:ahocorasick> function ahocorasick_finalize ] {

      - Parameters [1] {
        Parameter #0 [ <required> $id ]
      }
    }
    Function [ <internal:ahocorasick> function ahocorasick_add_patterns ] {

      - Parameters [2] {
        Parameter #0 [ <required> $id ]
        Parameter #1 [ <required> $patterns ]
      }
    }
  }
...

```