### PR TITLE
PHP 8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ CMakeLists.txt
 config.guess
 config.h
 config.h.in
+config.h.in~
 config.status
 config.sub
 configure
@@ -49,10 +50,9 @@ configure.ac
 install-sh
 libtool
 ltmain.sh
+ltmain.sh.backup
 Makefile*
 missing
 mkinstalldirs
-
-
-
+run-tests.php
 

--- a/src/php_ahocorasick.c
+++ b/src/php_ahocorasick.c
@@ -66,40 +66,16 @@ static char exception_buffer[8192];
 
 ZEND_DECLARE_MODULE_GLOBALS(ahocorasick)
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_match, 0, 0, 2)
-	ZEND_ARG_INFO(0, needle)
-	ZEND_ARG_INFO(0, id)
-	ZEND_ARG_INFO(0, findAll)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_id, 0, 0, 1)
-	ZEND_ARG_INFO(0, id)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_init, 0, 0, 1)
-	ZEND_ARG_INFO(0, data)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_add_patterns, 0, 0, 2)
-	ZEND_ARG_INFO(0, id)
-	ZEND_ARG_INFO(0, patterns)
-ZEND_END_ARG_INFO()
-
-
-static zend_function_entry ahocorasick_functions[] = {
-    PHP_FE(ahocorasick_match,          arginfo_ahocorasick_match)
-    PHP_FE(ahocorasick_init,           arginfo_ahocorasick_init)
-    PHP_FE(ahocorasick_deinit,         arginfo_ahocorasick_id)
-    PHP_FE(ahocorasick_isValid,        arginfo_ahocorasick_id)
-    PHP_FE(ahocorasick_finalize,       arginfo_ahocorasick_id)
-    PHP_FE(ahocorasick_add_patterns,   arginfo_ahocorasick_add_patterns)
-    PHP_FE_END
-};
+#if PHP_VERSION_ID < 80000
+#include "php_ahocorasick_legacy_arginfo.h"
+#else
+#include "php_ahocorasick_arginfo.h"
+#endif
 
 zend_module_entry ahocorasick_module_entry = {
     STANDARD_MODULE_HEADER,
     PHP_AHOCORASICK_EXTNAME,
-    ahocorasick_functions,
+    ext_functions,
     PHP_MINIT(ahocorasick),
     PHP_MSHUTDOWN(ahocorasick),
     PHP_RINIT(ahocorasick),

--- a/src/php_ahocorasick.h
+++ b/src/php_ahocorasick.h
@@ -34,6 +34,11 @@
 #endif
 
 // Compatibility
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#define TSRMLS_DC
+#endif
+
 #if PHP_MAJOR_VERSION < 7
 #define PHP7 0
 typedef long zend_long;

--- a/src/php_ahocorasick.stub.php
+++ b/src/php_ahocorasick.stub.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+
+/**
+ * @param resource $id
+ */
+function ahocorasick_match(string $needle, $id, bool $findAll=true): false|array {}
+
+/**
+ * @return resource
+ */
+function ahocorasick_init(array $data) {}
+
+/**
+ * @param resource $id
+ */
+function ahocorasick_deinit($id):bool {}
+
+/**
+ * @param resource $id
+ */
+function ahocorasick_isValid($id): bool {}
+
+/**
+ * @param resource $id
+ */
+function ahocorasick_finalize($id): bool {}
+
+/**
+ * @param resource $id
+ */
+function ahocorasick_add_patterns($id, array $patterns): bool {}
+

--- a/src/php_ahocorasick_arginfo.h
+++ b/src/php_ahocorasick_arginfo.h
@@ -1,0 +1,44 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ba403304a9d28e8231b959ba328e0b9ef4ae92c2 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ahocorasick_match, 0, 2, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO(0, needle, IS_STRING, 0)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, findAll, _IS_BOOL, 0, "true")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_init, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ahocorasick_deinit, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ahocorasick_isValid arginfo_ahocorasick_deinit
+
+#define arginfo_ahocorasick_finalize arginfo_ahocorasick_deinit
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ahocorasick_add_patterns, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_TYPE_INFO(0, patterns, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(ahocorasick_match);
+ZEND_FUNCTION(ahocorasick_init);
+ZEND_FUNCTION(ahocorasick_deinit);
+ZEND_FUNCTION(ahocorasick_isValid);
+ZEND_FUNCTION(ahocorasick_finalize);
+ZEND_FUNCTION(ahocorasick_add_patterns);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(ahocorasick_match, arginfo_ahocorasick_match)
+	ZEND_FE(ahocorasick_init, arginfo_ahocorasick_init)
+	ZEND_FE(ahocorasick_deinit, arginfo_ahocorasick_deinit)
+	ZEND_FE(ahocorasick_isValid, arginfo_ahocorasick_isValid)
+	ZEND_FE(ahocorasick_finalize, arginfo_ahocorasick_finalize)
+	ZEND_FE(ahocorasick_add_patterns, arginfo_ahocorasick_add_patterns)
+	ZEND_FE_END
+};

--- a/src/php_ahocorasick_legacy_arginfo.h
+++ b/src/php_ahocorasick_legacy_arginfo.h
@@ -1,0 +1,44 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ba403304a9d28e8231b959ba328e0b9ef4ae92c2 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_match, 0, 0, 2)
+	ZEND_ARG_INFO(0, needle)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_INFO(0, findAll)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_init, 0, 0, 1)
+	ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_deinit, 0, 0, 1)
+	ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO()
+
+#define arginfo_ahocorasick_isValid arginfo_ahocorasick_deinit
+
+#define arginfo_ahocorasick_finalize arginfo_ahocorasick_deinit
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ahocorasick_add_patterns, 0, 0, 2)
+	ZEND_ARG_INFO(0, id)
+	ZEND_ARG_INFO(0, patterns)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(ahocorasick_match);
+ZEND_FUNCTION(ahocorasick_init);
+ZEND_FUNCTION(ahocorasick_deinit);
+ZEND_FUNCTION(ahocorasick_isValid);
+ZEND_FUNCTION(ahocorasick_finalize);
+ZEND_FUNCTION(ahocorasick_add_patterns);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(ahocorasick_match, arginfo_ahocorasick_match)
+	ZEND_FE(ahocorasick_init, arginfo_ahocorasick_init)
+	ZEND_FE(ahocorasick_deinit, arginfo_ahocorasick_deinit)
+	ZEND_FE(ahocorasick_isValid, arginfo_ahocorasick_isValid)
+	ZEND_FE(ahocorasick_finalize, arginfo_ahocorasick_finalize)
+	ZEND_FE(ahocorasick_add_patterns, arginfo_ahocorasick_add_patterns)
+	ZEND_FE_END
+};


### PR DESCRIPTION
**1st** commit is enough for mimal compatibility

**3rd** commit is only for cleanup

**2nd** is to generate arginfo from stub

Pros:

*    take benefit of PHP 8 feature for maintaining argingo and function entries
*    compatible PHP 8 and PHP 7 (and even 5)
*    add type hinting (and return type hinting)

Cons:

*    requires PHP 8 to generate
